### PR TITLE
Added SBT-OSGi to allow this to generate an OSGi valid JAR artifact o…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,13 @@ scalacOptions ++= {
     Seq("-target:jvm-1.7")
 }
 
+lazy val sangriaStreamingApiOsgiSettings = osgiSettings ++ Seq(
+  OsgiKeys.exportPackage := Seq("sangria.streaming.*;version=${Bundle-Version}"),
+  OsgiKeys.privatePackage := Seq()
+)
+
+lazy val sangriaStreamingApiProject = project.in(file(".")).enablePlugins(SbtOsgi).settings(sangriaStreamingApiOsgiSettings:_*)
+
 git.remoteRepo := "git@github.com:sangria-graphql/sangria-streaming-api.git"
 
 // Publishing

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.4")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.8.0")


### PR DESCRIPTION
Added SBT-OSGi to allow it to generate an OSGi valid JAR artifact on publish or publishLocal, this allowed it to be used within an OSGi environment. Look at the file MANIFEST.MF inside the artifact JAR (result of publishLocal) before and after this change was added to see the changes. The change is that there are import and export packages defined there which allows OSGi to work out what imports and exports the JAR defines.