### PR TITLE
Get rid of Future in SubscriptionStream definition

### DIFF
--- a/src/main/scala/sangria/streaming/SubscriptionStream.scala
+++ b/src/main/scala/sangria/streaming/SubscriptionStream.scala
@@ -3,7 +3,6 @@ package sangria.streaming
 import scala.language.higherKinds
 
 import scala.annotation.implicitNotFound
-import scala.concurrent.Future
 
 @implicitNotFound(
   msg =
@@ -15,13 +14,13 @@ trait SubscriptionStream[StreamSource[_]] {
   def supported[T[X]](other: SubscriptionStream[T]): Boolean
 
   def single[T](value: T): StreamSource[T]
-  def singleFuture[T](value: Future[T]): StreamSource[T]
-  def first[T](s: StreamSource[T]): Future[T]
+  def singleF[T](value: StreamSource[T]): StreamSource[T]
+  def first[T](s: StreamSource[T]): StreamSource[T]
   def failed[T](e: Throwable): StreamSource[T]
   def onComplete[Ctx, Res](result: StreamSource[Res])(op: => Unit): StreamSource[Res]
-  def flatMapFuture[Ctx, Res, T](future: Future[T])(
+  def flatMap[Ctx, Res, T](f: StreamSource[T])(
       resultFn: T => StreamSource[Res]): StreamSource[Res]
-  def mapFuture[A, B](source: StreamSource[A])(fn: A => Future[B]): StreamSource[B]
+  def mapF[A, B](source: StreamSource[A])(fn: A => StreamSource[B]): StreamSource[B]
   def map[A, B](source: StreamSource[A])(fn: A => B): StreamSource[B]
   def merge[T](streams: Vector[StreamSource[T]]): StreamSource[T]
   def recover[T](stream: StreamSource[T])(fn: Throwable => T): StreamSource[T]

--- a/src/main/scala/sangria/streaming/future.scala
+++ b/src/main/scala/sangria/streaming/future.scala
@@ -11,11 +11,11 @@ object future {
 
     def map[A, B](source: Future[A])(fn: A => B): Future[B] = source.map(fn)
 
-    def singleFuture[T](value: Future[T]): Future[T] = value
+    def singleF[T](value: Future[T]): Future[T] = value
 
     def single[T](value: T): Future[T] = Future.successful(value)
 
-    def mapFuture[A, B](source: Future[A])(fn: A => Future[B]): Future[B] =
+    def mapF[A, B](source: Future[A])(fn: A => Future[B]): Future[B] =
       source.flatMap(fn)
 
     def first[T](s: Future[T]): Future[T] = s
@@ -27,7 +27,7 @@ object future {
         .map { x => op; x }
         .recover { case e => op; throw e }
 
-    def flatMapFuture[Ctx, Res, T](future: Future[T])(resultFn: T => Future[Res]): Future[Res] =
+    def flatMap[Ctx, Res, T](future: Future[T])(resultFn: T => Future[Res]): Future[Res] =
       future.flatMap(resultFn)
 
     def merge[T](streams: Vector[Future[T]]): Future[T] = Future.firstCompletedOf(streams)


### PR DESCRIPTION
Future in the stream definition cripples the ability to create a Futureless execution scheme in the main sangria (for example to create a Cats IO or ZIO based execution scheme).